### PR TITLE
upgrade Sonatype platform to current releases by default

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,27 @@
+# Versions of Sonatype Products to use.
+# These are specifically the Docker Tags as found on Docker Hub for
+# Sonatype's Offical Docker Images.
+#
+# If you are running on Apple Silicon, community provided Docker images
+# for ARM are available by setting NEXUS_DOCKER_IMAGE_ORGANIZATION=sonatypecommunity
+NEXUS_DOCKER_IMAGE_ORGANIZATION=sonatype
+NEXUS_IQ_SERVER_VERSION=1.183.0 # https://hub.docker.com/r/sonatype/nexus-iq-server
+NEXUS_REPOSITORY_VERSION=3.73.0 # https://hub.docker.com/r/sonatype/nexus3
+
+# Where to store data for Sonatype Products (and Team City)
+DOCKER_ROOT_VOLUME_MOUNT_POINT=./data
+
+# If you have a valid Sonatype License File, set the full path to it here
+NEXUS_LICENSE_PATH=./config/sonatype-license-all.lic
+
 # Your UserID and Group ID - defaults below are for OSX
 UID=501
 GID=20
+
+# If you want to access your Nexus Repository or Sonatype IQ Server via a FQDN, set these here!
+# If you are using nGrok - absolutely it is best practice to set these FQDNs here.
+#NXRM_FQDN_URL=
+#NXLC_FQDN_URL=
 
 # Some profiles have a reverse proxy provided by nGinx.
 # This is the version of NGINX to use:
@@ -12,16 +33,6 @@ PG_DB_NAME=nxiq
 PG_DB_USER=nxiq
 PG_DB_PASS=Letmin123
 
-# Versions of Sonatype Products to use.
-# These are specifically the Docker Tags as found on Docker Hub for 
-# Sonatype's Offical Docker Images.
-#
-# If you are running on Apple Silicon, community provided Docker Images 
-# for ARM are available by setting NEXUS_DOCKER_IMAGE_ORGANIZATION=madpah
-NEXUS_DOCKER_IMAGE_ORGANIZATION=sonatype
-NEXUS_IQ_SERVER_VERSION=1.168.0
-NEXUS_REPOSITORY_VERSION=3.61.0
-
 # We utilise a Configuration as Code Plugin for Nexus Repository.
 # This is the version available from Maven Central.
 NEXUS_CASC_PLUGIN_VERSION=3.45.0.1
@@ -30,17 +41,6 @@ NEXUS_CASC_PLUGIN_VERSION=3.45.0.1
 # Specifically - the Docker Tag for the Official Team City Docker 
 # Image on Docker Hub.
 TEAMCITY_SERVER_VERSION=2021.1.2
-
-# Where to store data for Sonatype Products and Team City
-DOCKER_ROOT_VOLUME_MOUNT_POINT=./data
-
-# If you have a valid Sonatype License File, set the full path to it here
-NEXUS_LICENSE_PATH=./config/sonatype-license-all.lic
-
-# If you want to access your Nexus Repository or Sonatype IQ Server via a FQDN, set these here!
-# If you are using nGrok - absolutely it is best practice to set these FQDNs here.
-#NXRM_FQDN_URL=
-#NXLC_FQDN_URL=
 
 # Path to config.json for Sonatype Webhook Handler
 WEBHOOK_HANDLER_CONFIG_PATH=/path/to/config.json


### PR DESCRIPTION
by default, when new user copy/pastes instructions provided in README, we expect to have latest versions of Nexus Repo and IQ Server, as provided from `.env-example`

(this does not change anything for users who have their own `.env` from an old run)

tested successfully with `direct` profile

it seems `proxied` profile does not work, but the issue is independent from this version upgrade: #26 opened...

this fixes #13 