### PR TITLE
feat: use docker volumes & nxrm pro to use PostgreSQL

### DIFF
--- a/config/nexus-iq-config.yaml
+++ b/config/nexus-iq-config.yaml
@@ -69,14 +69,14 @@ server:
       - type: file
 
         # The file to which current statements will be logged.
-        currentLogFilename: ./log/request.log
+        currentLogFilename: /var/log/nexus-iq-server/request.log
 
         logFormat: '%clientHost %l %user [%date] "%requestURL" %statusCode %bytesSent %elapsedTime "%header{User-Agent}"'
 
         # When the log file rotates, the archived log will be renamed to this and gzipped. The
         # %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
         # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
-        archivedLogFilenamePattern: ./log/request-%d.log.gz
+        archivedLogFilenamePattern: /var/log/nexus-iq-server/request-%d.log.gz
 
         # The number of archived files to keep.
         archivedFileCount: 5
@@ -162,26 +162,26 @@ logging:
       appenders:
         - type: file
           # The file to which audit statements will be logged.
-          currentLogFilename: ./log/audit.log
+          currentLogFilename: /var/log/nexus-iq-server/audit.log
           # When the audit log file rotates, the archived audit log will be renamed to this and gzipped. The
           # %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
           # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
           #
           # If archive is true, this must be specified.
-          archivedLogFilenamePattern: ./log/audit-%d.log.gz
+          archivedLogFilenamePattern: /var/log/nexus-iq-server/audit-%d.log.gz
           # The number of archived audit log files to keep.
           archivedFileCount: 5
     "com.sonatype.insight.policy.violation":
       appenders:
         - type: file
           # The file to which policy violations will be logged.
-          currentLogFilename: ./log/policy-violation.log
+          currentLogFilename: /var/log/nexus-iq-server/policy-violation.log
           # When the policy violation log file rotates, the archived policy violation log will be renamed to this
           # and gzipped. The %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
           # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
           #
           # If archive is true, this must be specified.
-          archivedLogFilenamePattern: ./log/policy-violation-%d.log.gz
+          archivedLogFilenamePattern: /var/log/nexus-iq-server/policy-violation-%d.log.gz
           # The number of archived policy violation log files to keep.
           archivedFileCount: 5
 
@@ -203,14 +203,14 @@ logging:
       logFormat: "%d{'yyyy-MM-dd HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
 
       # The file to which current statements will be logged.
-      currentLogFilename: ./log/clm-server.log
+      currentLogFilename: /var/log/nexus-iq-server/clm-server.log
 
       # When the log file rotates, the archived log will be renamed to this and gzipped. The
       # %d is replaced with the previous day (yyyy-MM-dd). Custom rolling windows can be created
       # by passing a SimpleDateFormat-compatible format as an argument: "%d{yyyy-MM-dd-hh}".
       #
       # If archive is true, this must be specified.
-      archivedLogFilenamePattern: ./log/clm-server-%d.log.gz
+      archivedLogFilenamePattern: /var/log/nexus-iq-server/clm-server-%d.log.gz
 
       # The number of archived files to keep.
       archivedFileCount: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.9'
 
-x-env-license: &env-license-volume '${NEXUS_LICENSE_PATH:?err}:/sonatype-license.lic'
+x-env-license: &env-license-volume '${NEXUS_LICENSE_PATH:?err}:/sonatype-license.lic:ro'
 
 x-nxrm3-healthcheck: &nxrm3-healthcheck
   test:
@@ -26,9 +26,11 @@ x-nxrm3-volume-casc-config: &nxrm3-volume-casc-config './config/nexus-repo-casc.
 
 x-nxrm3-volume-casc-config-oss: &nxrm3-volume-casc-config-oss './config/nexus-repo-casc-oss.yaml:/opt/nexus.yml:ro'
 
-x-nxrm3-volume-data: &nxrm3-volume-data 'nxrm-data:/nexus-data'
+x-nxrm3-volume-data: &nxrm3-volume-data 'nxrm-data:/opt/sonatype/sonatype-work'
 
 x-pgsql-volume-data: &pgsql-volume-data 'pg-data:/var/lib/postgresql/data'
+
+x-pgsql-nxrm-volume-data: &pgsql-nxrm-volume-data 'pg-nxrm-data:/var/lib/postgresql/data'
 
 
 secrets:
@@ -37,8 +39,11 @@ secrets:
 
 services:
 
-  nxiq_direct:
+  nxiq-direct:
     image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus-iq-server:${NEXUS_IQ_SERVER_VERSION:?err}"
+    depends_on:
+      postgres:
+        condition: service_healthy
     environment:
       JAVA_OPTS: "-Ddw.baseUrl=${NXLC_FQDN_URL:-http://iq.localhost:8070} -Djava.util.prefs.userRoot=/sonatype-work/javaprefs"
       DATABASE_TYPE: postgresql
@@ -59,12 +64,12 @@ services:
       - "./config/nexus-iq-config.yaml:/etc/nexus-iq-server/config.yml:delegated"
       - *x-nxiq-volume-data
       - *x-nxiq-volume-logs
+    
+  nxiq-proxied:
+    image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus-iq-server:${NEXUS_IQ_SERVER_VERSION:?err}"
     depends_on:
       postgres:
         condition: service_healthy
-
-  nxiq-proxied:
-    image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus-iq-server:${NEXUS_IQ_SERVER_VERSION:?err}"
     environment:
       JAVA_OPTS: "-Ddw.baseUrl=${NXLC_FQDN_URL:-http://iq.localhost} -Djava.util.prefs.userRoot=/sonatype-work/javaprefs"
       DATABASE_TYPE: postgresql
@@ -86,16 +91,17 @@ services:
       - "./config/nexus-iq-config.yaml:/etc/nexus-iq-server/config.yml:delegated"
       - *x-nxiq-volume-data
       - *x-nxiq-volume-logs
-    depends_on:
-      postgres:
-        condition: service_healthy
 
-  nxrm3_direct:
+  nxrm3-direct:
     image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus3:${NEXUS_REPOSITORY_VERSION:?err}"
+    depends_on:
+      postgres-nxrm:
+        condition: service_healthy
     environment:
       BASE_URL: "${NXRM_FQDN_URL:-http://repo.localhost:8081}"
+      DATABASE_PASSWORD: ${PG_DB_PASS:?err}
+      INSTALL4J_ADD_VM_PARAMS: "-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Dnexus.licenseFile=/sonatype-license.lic -Dnexus.datastore.enabled=true -Djava.util.prefs.userRoot=$${NEXUS_DATA}/javaprefs -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://postgres-nxrm:5432/nxrm -Dnexus.datastore.nexus.username=nxrm -Dnexus.datastore.nexus.password=$${DATABASE_PASSWORD} -Dnexus.datastore.clustered.enabled=true"
       NEXUS_SECURITY_RANDOMPASSWORD: 'false'
-      NEXUS_CASC_CONFIG: '/opt/nexus.yml'
       NEXUS_IQ_BASE_URL: "${NXLC_FQDN_URL:-http://iq.localhost:8070}"
     healthcheck:
       <<: *nxrm3-healthcheck
@@ -108,9 +114,6 @@ services:
       - admin_password
     volumes:
       - *env-license-volume
-      - *nxrm3-volume-nexus-properties
-      - *nxrm3-volume-casc-config
-      - *nxrm3-volume-data
 
   nxrm3_direct_oss:
     image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus3:${NEXUS_REPOSITORY_VERSION:?err}"
@@ -127,17 +130,21 @@ services:
       - repoOssDemo
     secrets:
       - admin_password
-    volumes:
-      - *nxrm3-volume-nexus-properties
-      - *nxrm3-volume-casc-config-oss
-      - *nxrm3-volume-data
+    # volumes:
+    #   - *nxrm3-volume-nexus-properties
+    #   - *nxrm3-volume-casc-config-oss
+    #   - *nxrm3-volume-data
 
   nxrm3-proxied:
     image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus3:${NEXUS_REPOSITORY_VERSION:?err}"
+    depends_on:
+      postgres-nxrm:
+        condition: service_healthy
     environment:
-      BASE_URL: "${NXRM_FQDN_URL:-http://repo.localhost}"
+      BASE_URL: "${NXRM_FQDN_URL:-http://repo.localhost}"    
+      DATABASE_PASSWORD: ${PG_DB_PASS:?err}
+      INSTALL4J_ADD_VM_PARAMS: "-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Dnexus.licenseFile=/sonatype-license.lic -Dnexus.datastore.enabled=true -Djava.util.prefs.userRoot=$${NEXUS_DATA}/javaprefs -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://postgres-nxrm:5432/nxrm -Dnexus.datastore.nexus.username=nxrm -Dnexus.datastore.nexus.password=$${DATABASE_PASSWORD} -Dnexus.datastore.clustered.enabled=true"
       NEXUS_SECURITY_RANDOMPASSWORD: 'false'
-      # NEXUS_CASC_CONFIG: '/opt/nexus.yml'
       NEXUS_IQ_BASE_URL: "${NXLC_FQDN_URL:-http://iq.localhost}"
     healthcheck:
       <<: *nxrm3-healthcheck
@@ -153,9 +160,6 @@ services:
       - admin_password
     volumes:
       - *env-license-volume
-      - *nxrm3-volume-nexus-properties
-      - *nxrm3-volume-casc-config
-      - *nxrm3-volume-data
 
   postgres:
     image: "postgres:16.0-alpine3.18"
@@ -173,6 +177,28 @@ services:
     user: '${UID}:${GID}'
     volumes:
       - *pgsql-volume-data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PG_DB_USER:?err}"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
+  postgres-nxrm:
+    image: "postgres:16.0-alpine3.18"
+    environment:
+      - POSTGRES_USER=nxrm
+      - POSTGRES_PASSWORD=${PG_DB_PASS:?err}
+      - POSTGRES_DB=nxrm
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    networks:
+      - default
+      - platform
+    ports:
+      - '5433:5432'
+    shm_size: 128mb
+    user: '${UID}:${GID}'
+    volumes:
+      - *pgsql-nxrm-volume-data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${PG_DB_USER:?err}"]
       interval: 1s
@@ -398,3 +424,4 @@ volumes:
   nxiq-logs:
   nxrm-data:
   pg-data:
+  pg-nxrm-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
     volumes:
       - *pgsql-nxrm-volume-data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${PG_DB_USER:?err}"]
+      test: ["CMD-SHELL", "pg_isready -U nxrm"]
       interval: 1s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,15 +16,19 @@ x-nxrm3-healthcheck: &nxrm3-healthcheck
   retries: 10
   start_period: 40s
 
+x-nxiq-volume-data: &x-nxiq-volume-data 'nxiq-data:/sonatype-work'
+
+x-nxiq-volume-logs: &x-nxiq-volume-logs 'nxiq-logs:/nxiq-logs'
+
 x-nxrm3-volume-nexus-properties: &nxrm3-volume-nexus-properties './config/nexus-repo.properties:/nexus-data/etc/nexus.properties'
 
 x-nxrm3-volume-casc-config: &nxrm3-volume-casc-config './config/nexus-repo-casc.yaml:/opt/nexus.yml:ro'
 
 x-nxrm3-volume-casc-config-oss: &nxrm3-volume-casc-config-oss './config/nexus-repo-casc-oss.yaml:/opt/nexus.yml:ro'
 
-x-nxrm3-volume-data: &nxrm3-volume-data '${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/nexus-data:/nexus-data:delegated'
+x-nxrm3-volume-data: &nxrm3-volume-data 'nxrm-data:/nexus-data'
 
-x-pgsql-volume-data: &pgsql-volume-data '${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/pgdata:/var/lib/postgresql/data/pgdata:delegated'
+x-pgsql-volume-data: &pgsql-volume-data 'pg-data:/var/lib/postgresql/data'
 
 
 secrets:
@@ -53,8 +57,8 @@ services:
     volumes:
       - *env-license-volume
       - "./config/nexus-iq-config.yaml:/etc/nexus-iq-server/config.yml:delegated"
-      - "${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/iq-data:/sonatype-work:delegated"
-      - "${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/iq-logs:/opt/sonatype/nexus-iq-server/log:delegated"
+      - *x-nxiq-volume-data
+      - *x-nxiq-volume-logs
     depends_on:
       postgres:
         condition: service_healthy
@@ -80,8 +84,8 @@ services:
     volumes:
       - *env-license-volume
       - "./config/nexus-iq-config.yaml:/etc/nexus-iq-server/config.yml:delegated"
-      - "${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/iq-data:/sonatype-work:delegated"
-      - "${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/iq-logs:/opt/sonatype/nexus-iq-server/log:delegated"
+      - *x-nxiq-volume-data
+      - *x-nxiq-volume-logs
     depends_on:
       postgres:
         condition: service_healthy
@@ -109,12 +113,7 @@ services:
       - *nxrm3-volume-data
 
   nxrm3_direct_oss:
-    build:
-      context: ./images/nxrm3
-      args:
-        NEXUS_DOCKER_IMAGE_ORGANIZATION: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}"
-        NEXUS_REPOSITORY_VERSION: "${NEXUS_REPOSITORY_VERSION}"
-        NEXUS_CASC_PLUGIN_VERSION: "${NEXUS_CASC_PLUGIN_VERSION}"
+    image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus3:${NEXUS_REPOSITORY_VERSION:?err}"
     environment:
       BASE_URL: 'http://repo.localhost:8081'
       NEXUS_SECURITY_RANDOMPASSWORD: 'false'
@@ -134,16 +133,11 @@ services:
       - *nxrm3-volume-data
 
   nxrm3-proxied:
-    build:
-      context: ./images/nxrm3
-      args:
-        NEXUS_DOCKER_IMAGE_ORGANIZATION: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}"
-        NEXUS_REPOSITORY_VERSION: "${NEXUS_REPOSITORY_VERSION}"
-        NEXUS_CASC_PLUGIN_VERSION: "${NEXUS_CASC_PLUGIN_VERSION}"
+    image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus3:${NEXUS_REPOSITORY_VERSION:?err}"
     environment:
       BASE_URL: "${NXRM_FQDN_URL:-http://repo.localhost}"
       NEXUS_SECURITY_RANDOMPASSWORD: 'false'
-      NEXUS_CASC_CONFIG: '/opt/nexus.yml'
+      # NEXUS_CASC_CONFIG: '/opt/nexus.yml'
       NEXUS_IQ_BASE_URL: "${NXLC_FQDN_URL:-http://iq.localhost}"
     healthcheck:
       <<: *nxrm3-healthcheck
@@ -175,6 +169,7 @@ services:
       - platform
     ports:
       - '5432:5432'
+    shm_size: 128mb
     user: '${UID}:${GID}'
     volumes:
       - *pgsql-volume-data
@@ -397,3 +392,9 @@ networks:
   default: null
   platform: null
   teamcity: null
+
+volumes:
+  nxiq-data:
+  nxiq-logs:
+  nxrm-data:
+  pg-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ x-nxrm3-healthcheck: &nxrm3-healthcheck
 
 x-nxiq-volume-data: &x-nxiq-volume-data 'nxiq-data:/sonatype-work'
 
-x-nxiq-volume-logs: &x-nxiq-volume-logs 'nxiq-logs:/nxiq-logs'
+x-nxiq-volume-logs: &x-nxiq-volume-logs 'nxiq-logs:/opt/sonatype/nexus-iq-server/log'
 
 x-nxrm3-volume-nexus-properties: &nxrm3-volume-nexus-properties './config/nexus-repo.properties:/nexus-data/etc/nexus.properties'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ x-nxrm3-healthcheck: &nxrm3-healthcheck
 
 x-nxiq-volume-data: &x-nxiq-volume-data 'nxiq-data:/sonatype-work'
 
-x-nxiq-volume-logs: &x-nxiq-volume-logs 'nxiq-logs:/opt/sonatype/nexus-iq-server/log'
+x-nxiq-volume-logs: &x-nxiq-volume-logs 'nxiq-logs:/var/log/nexus-iq-server'
 
 x-nxrm3-volume-nexus-properties: &nxrm3-volume-nexus-properties './config/nexus-repo.properties:/nexus-data/etc/nexus.properties'
 


### PR DESCRIPTION
This PR initially set out to resolve #37 - however in order to achieve this, #16 was also required to be included.

This is due to the nature of how the Sonatype Nexus Repository Container Images use the `/nexus-data` directory.